### PR TITLE
added support for systems without file_get_contents. Also added a mimetype check to prevent the extension from sending anything except png/jpeg to tinify-api

### DIFF
--- a/Classes/Service/TinypngService.php
+++ b/Classes/Service/TinypngService.php
@@ -15,6 +15,7 @@ namespace Scarbous\MrTinypng\Service;
  */
 
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class TinypngService
@@ -54,8 +55,8 @@ class TinypngService implements SingletonInterface
 	public function shrinkImage($source, $target = NULL)
 	{
 		$target = $target === NULL ? $source : $target;
-		$sourceData = file_get_contents($source);
-		$targetData = \Tinify\fromBuffer($sourceData)->toBuffer();;
+		$sourceData = GeneralUtility::getURL($source);
+		$targetData = \Tinify\fromBuffer($sourceData)->toBuffer();
 		file_put_contents($target, $targetData);
 		$reduction = strlen($sourceData) - strlen($targetData);
 		unset($sourceData,$targetData);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,18 +1,41 @@
 <?php
-$EM_CONF[$_EXTKEY] = array(
-    'title' => 'Mr.tinypng',
-    'description' => '',
-    'category' => 'misc',
-    'author' => 'Sascha Heilmeier',
-    'author_email' => 'sheilmeier@gmail.com',
-    'author_company' => '',
-    'state' => 'beta',
-    'clearCacheOnLoad' => 0,
-    'version' => '0.3.0',
-    'constraints' => array(
-		'depends' => array (
+
+/***************************************************************
+ * Extension Manager/Repository config file for ext "mr_tinypng".
+ *
+ * Auto generated 07-03-2016 16:42
+ *
+ * Manual updates:
+ * Only the data in the array - everything else is removed by next
+ * writing. "version" and "dependencies" must not be touched!
+ ***************************************************************/
+
+$EM_CONF[$_EXTKEY] = array (
+	'title' => 'Mr.tinypng',
+	'description' => '',
+	'category' => 'misc',
+	'author' => 'Sascha Heilmeier',
+	'author_email' => 'sheilmeier@gmail.com',
+	'author_company' => '',
+	'state' => 'beta',
+	'clearCacheOnLoad' => 0,
+	'version' => '0.3.1',
+	'constraints' =>
+	array (
+		'depends' =>
+		array (
 			'typo3' => '6.2.0-7.6.99',
-			'php' => '5.5.0-7.0.99'
+			'php' => '5.5.0-7.0.99',
 		),
-    ),
+		'conflicts' =>
+		array (
+		),
+		'suggests' =>
+		array (
+		),
+	),
+	'uploadfolder' => false,
+	'createDirs' => NULL,
+	'clearcacheonload' => false,
 );
+


### PR DESCRIPTION
Sorry for the whitespace changes. We have quite strict, automatted coding style guidelines. (If you didnt know: try appending ?w=1 to the url in your browser window to ignore whitespace changes)
