### PR TITLE
Limit shrink to JPG or PNG files

### DIFF
--- a/Classes/Service/TinypngService.php
+++ b/Classes/Service/TinypngService.php
@@ -24,15 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TinypngService implements SingletonInterface
 {
-	/**
-	 * PNG mime-type
-	 */
-	const PNG = 'image/png';
-
-	/**
-	 * JPG mime-type
-	 */
-	const JPG = 'image/jpeg';
 
 	/**
 	 * Validate API
@@ -76,7 +67,7 @@ class TinypngService implements SingletonInterface
 	{
 		
 	    	try {
-			if (in_array(mime_content_type($source), array(self::JPG, self::PNG))) {
+			if (in_array(mime_content_type($source), self::getAllowedMimeTypes())) {
 				$target = $target === NULL ? $source : $target;
 				$sourceData = GeneralUtility::getURL($source);
 				$targetData = \Tinify\fromBuffer($sourceData)->toBuffer();
@@ -101,4 +92,14 @@ class TinypngService implements SingletonInterface
 			return false;
 	        }
 	}
+
+    /**
+     * Get list of allowed mime types from extension configuration
+     * 
+     * @return array
+     */
+    public static function getAllowedMimeTypes() {
+        $extConfig = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['mr_tinypng']);
+        return \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode('|', $extConfig['mimeTypes'], TRUE);
+    }
 }

--- a/Classes/SignalSlots/FileProcessingService.php
+++ b/Classes/SignalSlots/FileProcessingService.php
@@ -94,7 +94,7 @@ class FileProcessingService {
 		$testi = $file->getMimeType();
 		// optimize only FE images
 		if ($context == 'Image.CropScaleMask' && TYPO3_MODE !== 'BE' &&
-			($file->getMimeType() == TinypngService::PNG || $file->getMimeType() == TinypngService::JPG)
+			in_array($file->getMimeType(), TinypngService::getAllowedMimeTypes())
 		) {
 			$properties = $processedFile->getProperties();
 			if (

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,5 @@
 # cat=basic/11; type=string; label=tinypng API Key
 tinypngApiKey=
+
+# cat=basic/11; type=options[both PNG and JPG=image/png|image/jpeg, PNG only=image/png, JPG only=image/jpeg]; label=File types to tinify
+mimeTypes=image/png;image/jpeg


### PR DESCRIPTION
In one of my projects, I only want to shrink PNG files, but never JPG files. So I added this feature:

In the extension configuration, you can choose if you want to shrink JPG, PNG or both file types (default).