### PR TITLE
[BUGFIX] Use correct namespace for CommandController

### DIFF
--- a/Classes/Command/TinyPngCommandController.php
+++ b/Classes/Command/TinyPngCommandController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scarbous\MrTinypng\CMS\Command;
+namespace Scarbous\MrTinypng\Command;
 
 use TYPO3\CMS\Core\Resource\ProcessedFile;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -9,7 +9,7 @@ call_user_func(function ($extKey) {
     if (TYPO3_MODE === 'BE' && !(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
 
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][$extKey] =
-            \Scarbous\MrTinypng\CMS\Command\TinyPngCommandController::class;
+            \Scarbous\MrTinypng\Command\TinyPngCommandController::class;
 
         /**
          * Register Backend Module


### PR DESCRIPTION
The namespace was defined with CMS, but is not present in folder "CMS". So the class could not be found in composer based installations.