### PR TITLE
[BUGFIX] Do not try to reduce files with empty names

### DIFF
--- a/Classes/CMS/Core/Resource/ProcessedFileRepository.php
+++ b/Classes/CMS/Core/Resource/ProcessedFileRepository.php
@@ -82,7 +82,8 @@ class ProcessedFileRepository extends \TYPO3\CMS\Core\Resource\ProcessedFileRepo
                 $queryBuilder->expr()->eq(
                     'reduce_it',
                     $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
-                )
+                ),
+                $queryBuilder->expr()->isNotNull('name')
             );
 
         return $queryBuilder;


### PR DESCRIPTION
Records in sys_file_processedfile can contain NULL in field name. These records causes problems in some environments and should be ignored. Ignoring them does not have any negative effects, because there is not image data to reduce.